### PR TITLE
Feature/fix ros2 launching

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Ubuntu 20.04 + ROS2 Galatic is required.
 ```sh
 cd ~
 mkdir ros2_ws
-cd ros2/ws
+cd ros2_ws
 mksir src
 cd src
-git clone https://github.com/mangdangroboticsclub/mini_pupper_ros.git --branch=ros2
-git clone https://github.com/chvmp/champ.git --branch=ros2
+git clone https://github.com/mangdangroboticsclub/mini_pupper_ros.git -b ros2
+git clone --recursive https://github.com/chvmp/champ -b ros2
 cd ..
 colcon build
 sudo apt-get install ros-galactic-teleop-twist-keyboard ros-galactic-cartographer-ros

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ mksir src
 cd src
 git clone https://github.com/mangdangroboticsclub/mini_pupper_ros.git -b ros2
 git clone --recursive https://github.com/chvmp/champ -b ros2
+rosdep install --from-paths src --ignore-src -r -y
 cd ..
 colcon build
 sudo apt-get install ros-galactic-teleop-twist-keyboard ros-galactic-cartographer-ros
@@ -18,18 +19,14 @@ sudo apt-get install ros-galactic-teleop-twist-keyboard ros-galactic-cartographe
 ## 2. Test in RVIZ
 ```sh
 # Terminal 1
-source /opt/ros/galactic/setup.bash
 source ~/ros2_ws/install/setup.bash
 ros2 launch mini_pupper_bringup bringup.launch.py
 
 # Terminal 2
-source /opt/ros/galactic/setup.bash
 source ~/ros2_ws/install/setup.bash
 rviz2 -d src/champ/champ_description/rviz/urdf_viewer.rviz
 
 # Terminal 3
-source /opt/ros/galactic/setup.bash
-source ~/ros2_ws/install/setup.bash
 ros2 run teleop_twist_keyboard teleop_twist_keyboard
 # Then control robot dog with your keyboard
 ```
@@ -37,18 +34,14 @@ ros2 run teleop_twist_keyboard teleop_twist_keyboard
 ## 3. Test in Gazebo
 ```sh
 # Terminal 1
-source /opt/ros/galactic/setup.bash
 source ~/ros2_ws/install/setup.bash
 ros2 launch mini_pupper_gazebo gazebo.launch.py
 
 # Terminal 2
-source /opt/ros/galactic/setup.bash
 source ~/ros2_ws/install/setup.bash
 rviz2 -d src/champ/champ_description/rviz/urdf_viewer.rviz
 
 # Terminal 3
-source /opt/ros/galactic/setup.bash
-source ~/ros2_ws/install/setup.bash
 ros2 run teleop_twist_keyboard teleop_twist_keyboard
 # Then control robot dog with your keyboard
 ```
@@ -56,18 +49,14 @@ ros2 run teleop_twist_keyboard teleop_twist_keyboard
 ## 4. Cartographer Test in Gazebo
 ```sh
 # Terminal 1
-source /opt/ros/galactic/setup.bash
 source ~/ros2_ws/install/setup.bash
 ros2 launch mini_pupper_gazebo gazebo.launch.py
 
 # Terminal 2
-source /opt/ros/galactic/setup.bash
 source ~/ros2_ws/install/setup.bash
 ros2 launch mini_pupper_navigation slam.launch.py use_sim_time:=true
 
 # Terminal 3
-source /opt/ros/galactic/setup.bash
-source ~/ros2_ws/install/setup.bash
 ros2 run teleop_twist_keyboard teleop_twist_keyboard
 # Then control robot dog with your keyboard
 ```

--- a/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
+++ b/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
@@ -1782,7 +1782,7 @@
   
   <gazebo>
     <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
-      <parameters>$(find mini_pupper_config)/config/ros_control/ros_control.yaml</parameters>
+      <parameters>$(find mini_pupper_gazebo)/config/ros_control/ros_control.yaml</parameters>
     </plugin>
   </gazebo>
   


### PR DESCRIPTION
1. Fixed some typos. 
2. simplified README.md for cleaner instructions 

Most of the ROS developers put the following in ~/.bashrc
```source /opt/ros/galactic/setup.bash```
So I removed it with reference to champ's README.md


