### PR TITLE
Set /use_sim_time as true while simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ roslaunch mini_pupper_bringup bringup.launch
 #### 2.3.2 Run Cartographer
 
 **You should run this command on PC**  
-**Notice: If you are using gazebo, set the param /use_sim_time in navigate.launch as true.**
 
 ```sh
 roslaunch mini_pupper_navigation slam.launch
@@ -313,7 +312,6 @@ roslaunch mini_pupper_bringup bringup.launch
 #### 2.4.3 Run Cartographer(for localization) and move_base
 
 **You should run this command on PC**  
-**Notice: If you are using gazebo, set the param /use_sim_time in navigate.launch as true.**
 
 ```sh
 roslaunch mini_pupper_navigation navigate.launch

--- a/mini_pupper_bringup/launch/champ_bringup.launch
+++ b/mini_pupper_bringup/launch/champ_bringup.launch
@@ -23,7 +23,7 @@
 
     <group ns="$(arg robot_name)">
         <param name="tf_prefix" value="$(arg robot_name)"/>
-        <param if="$(arg gazebo)" name="use_sim_time" value="true"/>
+        <param if="$(arg gazebo)" name="/use_sim_time" value="true"/>
 
         <!-- ==================== LOAD PARAMETERS ==================== -->
         <include file="$(find mini_pupper_description)/launch/description.launch">

--- a/mini_pupper_gazebo/README.md
+++ b/mini_pupper_gazebo/README.md
@@ -2,10 +2,12 @@
 
 You can also play with Mini Pupper with only your laptop or PC.  
 **Raspberry Pi does not have enough resources to simulate.**
+**Notice: Setting the param `/use_sim_time` as `true` is required for simulation.**
 
 ![nav](../imgs/instruction.gif)
 
-Launch the Gazebo simulator with the following command.
+Launch the Gazebo simulator with the following command.  
+The param `/use_sim_time` is set to `true` by this launch file.
 
 ```sh
 roslaunch mini_pupper_gazebo gazebo.launch
@@ -16,3 +18,4 @@ Run the following command in another terminal to send command to the robot.
 ```sh
 roslaunch champ_teleop teleop.launch
 ```
+

--- a/mini_pupper_gazebo/launch/gazebo.launch
+++ b/mini_pupper_gazebo/launch/gazebo.launch
@@ -10,8 +10,6 @@
     <arg name="world_init_y"       default="0.0" /> <!-- Y Initial position of the robot in Gazebo World -->
     <arg name="world_init_heading" default="0.0" /> <!-- Initial heading of the robot in Gazebo World -->
 
-    <param name="use_sim_time" value="true" />
-
     <include file="$(find mini_pupper_bringup)/launch/bringup.launch">
         <arg name="robot_name"             value="$(arg robot_name)"/>
         <arg name="gazebo"                 value="true"/>

--- a/mini_pupper_navigation/launch/navigate.launch
+++ b/mini_pupper_navigation/launch/navigate.launch
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-    <param name="/use_sim_time" value="false" />
     <arg name="robot_name" default="/"/>
     <arg name="rviz"       default="true"/>
 

--- a/mini_pupper_navigation/launch/slam.launch
+++ b/mini_pupper_navigation/launch/slam.launch
@@ -2,7 +2,6 @@
 <launch>
     <arg name="robot_name" default="/"/>
     <arg name="rviz"       default="false"/>
-    <param name="/use_sim_time" value="false" />
 
     <arg if="$(eval arg('robot_name') == '/')"  name="frame_prefix" value="" />
     <arg unless="$(eval arg('robot_name') == '/')" name="frame_prefix" value="$(arg robot_name)/" />


### PR DESCRIPTION
This PR is to change the settings so as not to overwrite the already defined param /use_sim_time.
This param has already set to "true" in champ_bringup.launch.

https://github.com/mangdangroboticsclub/mini_pupper_ros/blob/4c6064969b7041d4ff9a1cde991fb81d07b008f6/mini_pupper_bringup/launch/champ_bringup.launch#L26

Except for simulation, basically we don't need to use this parameter.
http://wiki.ros.org/Clock

This patch is created by @CullenSUN's report. Thanks.