### PR TITLE
changed name of executable in mini_pupper_navigation/launch/occupancy…

### DIFF
--- a/mini_pupper_navigation/launch/occupancy_grid.launch.py
+++ b/mini_pupper_navigation/launch/occupancy_grid.launch.py
@@ -44,7 +44,7 @@ def generate_launch_description():
 
         Node(
             package='cartographer_ros',
-            executable='occupancy_grid_node',
+            executable='cartographer_occupancy_grid_node',
             name='occupancy_grid_node',
             output='screen',
             parameters=[{'use_sim_time': use_sim_time}],


### PR DESCRIPTION
I installed cartographer with 
sudo apt-get -y install ros-humble-cartographer-ros
and noticed that the name of the executable does not match the launch file

This PR will ensure that
ros2 launch mini_pupper_navigation slam.launch.py use_sim_time:=true

will no longer produce the error message
Caught exception in launch (see debug for traceback): executable 'occupancy_grid_node' not found on the libexec directory '/opt/ros/humble/lib/cartographer_ros'