### PR TITLE
Fix imu sensor setting for humble

### DIFF
--- a/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
+++ b/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
@@ -1786,19 +1786,6 @@
     </plugin>
   </gazebo>
   
-  <gazebo>
-    <plugin filename="libhector_gazebo_ros_imu.so" name="imu_controller">
-      <updateRate>50.0</updateRate>
-      <bodyName>imu_link</bodyName>
-      <topicName>imu/data</topicName>
-      <accelDrift>0.005 0.005 0.005</accelDrift>
-      <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
-      <rateDrift>0.005 0.005 0.005 </rateDrift>
-      <rateGaussianNoise>0.005 0.005 0.005 </rateGaussianNoise>
-      <headingDrift>0.005</headingDrift>
-      <headingGaussianNoise>0.005</headingGaussianNoise>
-    </plugin>
-  </gazebo>
   <link name="imu_link">
     <inertial>
       <mass value="0.0001"/>
@@ -1806,10 +1793,24 @@
       <inertia ixx="1e-09" ixy="0.0" ixz="0.0" iyy="1e-09" iyz="0.0" izz="1e-09"/>
     </inertial>
   </link>
+
   <joint name="imu_joint" type="fixed">
     <parent link="base_link"/>
     <child link="imu_link"/>
   </joint>
+
+  <gazebo reference="imu_link">
+    <sensor name="imu_controller" type="imu">
+      <always_on>true</always_on>
+      <update_rate>50</update_rate>
+      <plugin name="gazebo_ros_imu_sensor" filename="libgazebo_ros_imu_sensor.so">
+          <ros>
+              <namespace>/imu</namespace>
+              <argument>~/out:=data</argument>
+          </ros>
+      </plugin>
+    </sensor>
+  </gazebo>
   
   <!--xacro:sensor_d435 parent="base_link">
   <origin xyz="0.08 0.0 0.07" rpy="0 0 0" />


### PR DESCRIPTION
## Proposed change(s)

Imu sensor was not working before this change. Because ROS2 humble need a different config. 
This change is with reference to [champ's config ]()

### Useful links (GitHub issues, forum threads, etc.)

[champ's imu config](https://github.com/chvmp/champ/blob/ros2/champ_description/urdf/accessories.urdf.xacro)

### Types of change(s)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

1. ros2 launch mini_pupper_config gazebo.launch.py
2. ros2 topic echo /imu/data

## Test Configuration

__Mini Pupper Version__  
Simulator

__Raspberry Pi OS + ROS version__  
N/A

__PC OS + ROS version__  
Ubuntu 22.04, ROS 2 Humble

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_ros/blob/ros2/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
