### PR TITLE
Fix launch file to avoid launching packages for real robots during simulation

### DIFF
--- a/mini_pupper_gazebo/launch/gazebo.launch.py
+++ b/mini_pupper_gazebo/launch/gazebo.launch.py
@@ -55,7 +55,7 @@ def generate_launch_description():
 
     robot_name = LaunchConfiguration("robot_name")
     sim = LaunchConfiguration("sim")
-    hardware_connected = LaunchConfiguration("hardware_connected")
+    joint_hardware_connected = LaunchConfiguration("joint_hardware_connected")
     rviz = LaunchConfiguration("rviz")
     lite = LaunchConfiguration("lite")
     world = LaunchConfiguration("world"),
@@ -111,8 +111,8 @@ def generate_launch_description():
         default_value='true',
         description='Enable use_sime_time to true'
     )
-    declare_hardware_connected = DeclareLaunchArgument(
-        name='hardware_connected',
+    declare_joint_hardware_connected = DeclareLaunchArgument(
+        name='joint_hardware_connected',
         default_value='false',
         description='Set to true if connected to a physical robot'
     )
@@ -124,7 +124,7 @@ def generate_launch_description():
             "robot_name": robot_name,
             "gazebo": sim,
             "rviz": rviz,
-            "hardware_connected": hardware_connected,
+            "joint_hardware_connected": joint_hardware_connected,
             "publish_foot_contacts": "true",
             "close_loop_odom": "true",
             "joint_controller_topic": "joint_group_effort_controller/joint_trajectory",
@@ -162,7 +162,7 @@ def generate_launch_description():
         declare_world_init_y,
         declare_world_init_heading,
         declare_sim,
-        declare_hardware_connected,
+        declare_joint_hardware_connected,
         mini_pupper_bringup_launch,
         champ_gazebo_launch
     ])


### PR DESCRIPTION
## Proposed change(s)

Update `hardware_connected` to `joint_hardware_connected` to avoid launching packages for real robots during simulation

### Useful links (GitHub issues, forum threads, etc.)

* #40 
* #45 

### Types of change(s)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions and ROS packages as appropriate so we can reproduce the test environment.

1. checkout https://github.com/Tiryoh/mangdang_mini_pupper_ros/tree/patch-19 and run `colcon build --symlink-install`
2. run `ros2 launch mini_pupper_gazebo gazebo.launch.py`
3. run `ros2 node list` and see no lidar or servo specific nodes are launched

## Test Configuration

__Mini Pupper Version__  
Simulator


__PC OS + ROS version__  
Ubuntu 22.04, ROS 2 Humble

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_ros/blob/ros2/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
