### PR TITLE
Update gazebo lidar scan frame_name

### DIFF
--- a/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
+++ b/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
@@ -1774,7 +1774,7 @@
           <argument>~/out:=/scan</argument>
         </ros>
         <output_type>sensor_msgs/LaserScan</output_type>
-        <frame_name>lidar</frame_name>
+        <frame_name>lidar_link</frame_name>
         <!--min_intensity>100.0</min_intensity-->
       </plugin>
     </sensor>


### PR DESCRIPTION
## Proposed change(s)

This pull request changes the frame_name of the scan topic to `lidar_link`.
This change is to match the configuration when using LD06.

https://github.com/mangdangroboticsclub/mini_pupper_ros/pull/45/files#diff-05da6729185417799ca0b81bf54d30ca675a1c6cb7e97600b963c19086c75d02

### Useful links (GitHub issues, forum threads, etc.)

* https://github.com/mangdangroboticsclub/mini_pupper_ros/pull/45

### Types of change(s)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification


1. `ros2 launch mini_pupper_gazebo gazebo.launch.py`
2. `ros2 launch mini_pupper_navigation bringup.launch.py use_sim_time:=true`
3. See the console log on the second terminal

## Test Configuration

__Mini Pupper Version__  
Simulator

__PC OS + ROS version__  
Ubuntu 22.04, ROS 2 Humble

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_ros/blob/ros2/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->

I don't know why but this helps to fix the following message

```
[rviz2-4] [INFO] [1678205135.199224077] [rviz2]: Message Filter dropping message: frame 'lidar' at time 1678205129.143 for reason 'discarding message because the queue is full'
```