### PR TITLE
Update for mini_pupper_control

### DIFF
--- a/mini_pupper_control/mini_pupper_control/servo_interface.py
+++ b/mini_pupper_control/mini_pupper_control/servo_interface.py
@@ -20,7 +20,7 @@
 import numpy as np
 import rclpy
 from rclpy.node import Node
-from trajectory_msgs.msg import JointTrajectory
+from sensor_msgs.msg import JointState
 from MangDang.mini_pupper.HardwareInterface import HardwareInterface
 
 
@@ -28,33 +28,13 @@ class ServoInterface(Node):
     def __init__(self):
         super().__init__('servo_interface')
         self.subscriber = self.create_subscription(
-            JointTrajectory, '/joint_group_effort_controller/joint_trajectory',
+            JointState, '/joint_command',
             self.cmd_callback, 1)
         self.hardware_interface = HardwareInterface()
 
     def cmd_callback(self, msg):
-        joint_positions = msg.points[0].positions
-        lf1_position = joint_positions[0]
-        lf2_position = joint_positions[1]
-        lf3_position = joint_positions[2]
-        rf1_position = joint_positions[3]
-        rf2_position = joint_positions[4]
-        rf3_position = joint_positions[5]
-        lb1_position = joint_positions[6]
-        lb2_position = joint_positions[7]
-        lb3_position = joint_positions[8]
-        rb1_position = joint_positions[9]
-        rb2_position = joint_positions[10]
-        rb3_position = joint_positions[11]
-
-        joint_angles = np.array([
-            [rf1_position, lf1_position, rb1_position, lb1_position],
-            [rf2_position, lf2_position, rb2_position, lb2_position],
-            [rf2_position + rf3_position, lf2_position + lf3_position,
-             rb2_position + rb3_position, lb2_position + lb3_position]
-        ])
+        joint_angles = np.array(msg.position).reshape(3, 4)
         self.hardware_interface.set_actuator_postions(joint_angles)
-
 
 def main(args=None):
     rclpy.init(args=args)


### PR DESCRIPTION
## Proposed change(s)

I have changed the data type of the ROS subscriber used in the servo interface to a more appropriate type.
Refactored the code related to joint_angles initialization in cmd_callback.
These changes will make the servo interface no longer use champ's topic data type.

### Types of change(s)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Code refactor (non-breaking change which refactors the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification
To verify these changes, I performed the following tests:

1. Publish /joint_command in JointState data type.
2. Launch the servo interface node.
2. Observe the movement of the Mini Pupper.

## Test Configuration

__Mini Pupper Version__  
Mini Pupper

__Raspberry Pi OS + ROS version__  
Ubuntu 22.04, ROS 2 Humble

__PC OS + ROS version__  
Ubuntu 22.04, ROS 2 Humble

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_ros/blob/ros2/CONTRIBUTING.md) guidelines.
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.