### PR TITLE
fix lidar link inconsistent issue

### DIFF
--- a/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
+++ b/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
@@ -101,7 +101,7 @@
       xyz="0 0 0" />
   </joint>
   <link
-    name="lidar">
+    name="lidar_link">
     <inertial>
       <origin
         xyz="1.56706411611127E-05 -5.16565672073303E-13 -0.0191835739440227"
@@ -148,20 +148,6 @@
       rpy="0 0 1.57" />
     <parent
       link="base_link" />
-    <child
-      link="lidar" />
-    <axis
-      xyz="0 0 0" />
-  </joint>
-  <link name="lidar_link" />
-  <joint
-    name="lidar_link_joint"
-    type="fixed">
-    <origin
-      xyz="0 0 0"
-      rpy="0 0 0" />
-    <parent
-      link="lidar" />
     <child
       link="lidar_link" />
     <axis
@@ -1741,11 +1727,10 @@
     <material>Gazebo/FlatBlack</material>
   </gazebo>
   
-  <gazebo reference="lidar">
+  <gazebo reference="lidar_link">
     <material>Gazebo/FlatBlack</material>
     <sensor type="ray" name="lidar">
       <always_on>true</always_on>
-      <visualize>false</visualize>
       <update_rate>30</update_rate>
       <pose>0 0 0 0 0 0</pose>
       <visualize>false</visualize>


### PR DESCRIPTION
## Proposed change(s)

Lidar and lidar_link was messed up. This fix is to make it correct. 

### Useful links (GitHub issues, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions and ROS packages as appropriate so we can reproduce the test environment.

1. ros2 launch mini_pupper_config gazebo.launch.py
2.  ros2 launch mini_pupper_config navigate.launch.py rviz:=true use_sim_time:=true


## Test Configuration

__Mini Pupper Version__  
[e.g. Simulator, Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro]
Simulator
__Raspberry Pi OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

__PC OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]
Ubuntu 22.04, ROS 2 Humble
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_ros/blob/ros2/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
