### PR TITLE
Fix display_interface.py subscribe error

### DIFF
--- a/mini_pupper_driver/mini_pupper_driver/display_interface.py
+++ b/mini_pupper_driver/mini_pupper_driver/display_interface.py
@@ -31,7 +31,7 @@ class DisplayNode(Node):
         super().__init__('display_interface')
         self.get_logger().info("Initializing display interface")
         self.bridge = CvBridge()
-        self.sub = self.create_subscription(Image, 'mini_pupper_lcd/image_raw')
+        self.sub = self.create_subscription(Image, 'mini_pupper_lcd/image_raw', self.callback, 10)
         self.get_logger().info("Creating LCD hardware interface")
         self.disp = ST7789()
         self.disp.begin()


### PR DESCRIPTION
## Proposed change(s)

Add a callback function to lcd subscription

### Useful links (GitHub issues, forum threads, etc.)

https://github.com/mangdangroboticsclub/mini_pupper_ros/pull/71#pullrequestreview-1381547448

### Types of change(s)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

`ros2 launch mini_pupper_driver display_interface.launch.py`

## Test Configuration

__Mini Pupper Version__  
Mini Pupper

__Raspberry Pi OS + ROS version__  
Ubuntu 22.04, ROS 2 Humble

__PC OS + ROS version__  
Ubuntu 22.04, ROS 2 Humble

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_ros/blob/ros2/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments
