### PR TITLE
Fix deprecated syntax

### DIFF
--- a/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
+++ b/mini_pupper_description/urdf/mini_pupper_description.urdf.xacro
@@ -1756,7 +1756,7 @@
       </ray>
       <plugin name="gazebo_ros_lidar_controller" filename="libgazebo_ros_ray_sensor.so">
         <ros>
-          <argument>~/out:=/scan</argument>
+          <remapping>~/out:=/scan</remapping>
         </ros>
         <output_type>sensor_msgs/LaserScan</output_type>
         <frame_name>lidar_link</frame_name>
@@ -1768,7 +1768,7 @@
   <gazebo>
     <plugin filename="libgazebo_ros_p3d.so" name="p3d_base_controller">
       <ros>
-          <argument>odom:=odom/ground_truth</argument>
+          <remapping>odom:=odom/ground_truth</remapping>
       </ros>
       <body_name>base_link</body_name>
       <frame_name>world</frame_name>
@@ -1805,7 +1805,7 @@
       <plugin name="gazebo_ros_imu_sensor" filename="libgazebo_ros_imu_sensor.so">
           <ros>
               <namespace>/imu</namespace>
-              <argument>~/out:=data</argument>
+              <remapping>~/out:=data</remapping>
           </ros>
       </plugin>
     </sensor>


### PR DESCRIPTION
When following README and do section "**2.1.2 Test in Gazebo**"

```sh
# Terminal 1
. ~/ros2_ws/install/setup.bash # setup.zsh if you use zsh instead of bash
ros2 launch mini_pupper_gazebo gazebo.launch.py rviz:=true

```
Before fix, we will see warning log like below:

```
[gzserver-7] [WARN] [1701704038.855909660] [rcl]: Found remap rule '~/out:=/scan'. This syntax is deprecated. Use '--ros-args --remap ~/out:=/scan' instead.
[gzserver-7] [WARN] [1701704038.858937522] [rcl]: Found remap rule '~/out:=/scan'. This syntax is deprecated. Use '--ros-args --remap ~/out:=/scan' instead.
[gzserver-7] [WARN] [1701704038.865962323] [rcl]: Found remap rule '~/out:=data'. This syntax is deprecated. Use '--ros-args --remap ~/out:=data' instead.
[gzserver-7] [WARN] [1701704038.869025534] [rcl]: Found remap rule '~/out:=data'. This syntax is deprecated. Use '--ros-args --remap ~/out:=data' instead.
```
After fix, above related logs won't be seen any more.

