### PR TITLE
Updated repo link in .minipupper.repos

### DIFF
--- a/.minipupper.repos
+++ b/.minipupper.repos
@@ -1,7 +1,7 @@
 repositories:
   champ/champ:
     type: git
-    url: https://github.com/chvmp/champ.git
+    url: https://github.com/mangdangroboticsclub/champ.git
     version: ros2
   champ/champ_teleop:
     type: git


### PR DESCRIPTION
The main change in this update is the modification of the link used in the .minipupper.repos file, which is used to download the related packages using git clone.

This change ensures that users can properly download and use the latest version of the champ package with 2 new fixes.