### PR TITLE
feat: added camera to URDF of robot, enabling camera usage in Gazebo

### DIFF
--- a/mini_pupper_description/urdf/mini_pupper_2/mini_pupper_description.urdf.xacro
+++ b/mini_pupper_description/urdf/mini_pupper_2/mini_pupper_description.urdf.xacro
@@ -1239,4 +1239,55 @@
     </sensor>
   </gazebo>
 
+  <!-- Simulated camera mounted to the front body -->
+  <link name="camera_link">
+    <visual>
+      <geometry>
+        <box>
+          <size>0.02 0.02 0.02</size>
+        </box>
+      </geometry>
+      <material>
+        <ambient>0 0 1 1</ambient>
+        <diffuse>0 0 1 1</diffuse>
+      </material>
+    </visual>
+  </link>
+
+  <joint name="bodyfront_camera_joint" type="fixed">
+    <parent link="Body_front"/>
+    <child link="camera_link"/>
+    <origin xyz="0.02 0 0.02" rpy="0 0 0"/>
+  </joint>
+
+  <gazebo reference="camera_link">
+    <sensor type="camera" name="sim_camera">
+      <always_on>true</always_on>
+      <update_rate>30.0</update_rate>
+      <visualize>true</visualize>
+
+      <camera name="camera">
+        <horizontal_fov>1.3962634</horizontal_fov>
+        <image>
+          <width>640</width>
+          <height>480</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>50</far>
+        </clip>
+      </camera>
+
+      <!-- Gazebo ROS plugin to publish /image_raw -->
+      <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+        <always_on>true</always_on>
+        <update_rate>30.0</update_rate>
+        <frame_name>camera_link</frame_name>
+        <image_topic_name>/image_raw</image_topic_name>
+        <!-- camera_info omitted to disable /camera_info -->
+      </plugin>
+    </sensor>
+  </gazebo>
+
 </robot>


### PR DESCRIPTION
#### Features
Added camera sensor to URDF of mini_pupper_2
#### Notes
`sensors/camera`does not have to be enabled as True in `mini_pupper_ros/mini_pupper_bringup/config/mini_pupper_2.yaml` for the camera sensor to operate in Gazebo, it can be left as False.