### PR TITLE
Fix: migrate CI and docs references from Humble to Jazzy

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - { ROS_DISTRO: humble, ROS_REPO: ros }
+          - { ROS_DISTRO: jazzy, ROS_REPO: ros }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ as per clause 5 of the Apache 2.0 License:
 
 ### Code Style
 
-We follow the [ROS code style guidelines](https://docs.ros.org/en/humble/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html) as closely as possible.
+We follow the [ROS code style guidelines](https://docs.ros.org/en/jazzy/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html) as closely as possible.
 Please ensure that any new contributions are compatible with C++17 and Python3.x.
 
 To check Python code style, run the following command in the ROS workspace.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![ROS2 VERSION](https://img.shields.io/badge/ROS-ROS%202%20Humble-brightgreen)](http://docs.ros.org/en/humble/index.html)
+[![ROS2 VERSION](https://img.shields.io/badge/ROS-ROS%202%20Jazzy-brightgreen)](http://docs.ros.org/en/jazzy/index.html)
 &nbsp;
 [![Ubuntu VERSION](https://img.shields.io/badge/Ubuntu-22.04-green)](https://ubuntu.com/)
 &nbsp;
@@ -10,13 +10,13 @@
 &nbsp;
 [![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2FLeggedRobot)](https://twitter.com/LeggedRobot)
 
-# Mini Pupper ROS 2 Humble
+# Mini Pupper ROS 2 Jazzy
 
 <p align="left">
   <img src="imgs/mini_pupper_2.jpg" alt="Mini Pupper 2" width="480"/>
 </p>
 
-A comprehensive ROS 2 robotics platform for autonomous navigation, computer vision, and multi-robot coordination. Built for research, education, and development on Ubuntu 22.04 with ROS 2 Humble.
+A comprehensive ROS 2 robotics platform for autonomous navigation, computer vision, and multi-robot coordination. Built for research, education, and development on Ubuntu 22.04 with ROS 2 Jazzy.
 
 ## Key Capabilities
 
@@ -43,7 +43,7 @@ Programmable dance sequences with audio synchronization capabilities.
 ## Quick Start
 
 ### Pre-built Images
-Flash the ready-to-use image containing Ubuntu 22.04, ROS 2 Humble, and all Mini Pupper packages:
+Flash the ready-to-use image containing Ubuntu 22.04, ROS 2 Jazzy, and all Mini Pupper packages:
 - **Mini Pupper 2**: [2024Oct.12.Ubuntu22.04.MD-MiniPupper2-Y.ROS2Humble.zip](https://drive.google.com/drive/folders/1_HNbIb2RDmHpwECjqiVlkylvU19BSfOh?usp=sharing)
 - **Mini Pupper**: [2024Oct.12.Ubuntu22.04.MD-MiniPupper.ROS2Humble.zip](https://drive.google.com/drive/folders/1jJm_6qBIYGGp2dpZNm668D0eH1JpfCqn?usp=sharing)
 

--- a/docs/detailed-setup-guide.md
+++ b/docs/detailed-setup-guide.md
@@ -7,7 +7,7 @@ For a more detailed guide, please refer to our [online documentation](https://mi
 
 Supported Software versions
 
-* Ubuntu 22.04 + ROS 2 Humble
+* Ubuntu 22.04 + ROS 2 Jazzy
 
 Supported Hardware versions
 
@@ -31,7 +31,7 @@ Ubuntu 22.04 is required.
 
 Before installation, you need to install the BSP(board support package) repo for your [Mini Pupper 2](https://github.com/mangdangroboticsclub/mini_pupper_2_bsp) or [Mini Pupper](https://github.com/mangdangroboticsclub/mini_pupper_bsp.git).
 
-After installing the driver software, install ROS 2 Humble is required, if the installation is unsuccessful, repeat the steps to install the package again.  
+After installing the driver software, install ROS 2 Jazzy is required, if the installation is unsuccessful, repeat the steps to install the package again.  
 
 ```sh
 cd ~
@@ -42,7 +42,7 @@ cd mini_pupper_ros
 
 Reference(Just for reference, don't need to do it again.): 
 
-[installation document for ROS Humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) or
+[installation document for ROS Humble](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html) or
 
 [unofficial ROS 2 installation script](https://github.com/Tiryoh/ros2_setup_scripts_ubuntu)
 
@@ -52,7 +52,7 @@ Reference(Just for reference, don't need to do it again.):
 PC Setup corresponds to PC (your desktop or laptop PC) for controlling Mini Pupper remotely or execute simulator, if the installation is unsuccessful, repeat the steps to install the package again.  
 __Do not apply these PC Setup commands to your Raspberry Pi on Mini Pupper.__
 
-Ubuntu 22.04 + ROS 2 Humble is required.  
+Ubuntu 22.04 + ROS 2 Jazzy is required.  
 
 ```sh
 cd ~
@@ -63,7 +63,7 @@ cd mini_pupper_ros
 
 Reference(Just for reference, don't need to do it again.): 
 
-[installation document for ROS Humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) or
+[installation document for ROS Humble](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html) or
 
 [unofficial ROS 2 installation script](https://github.com/Tiryoh/ros2_setup_scripts_ubuntu)
 
@@ -439,7 +439,7 @@ limitations under the License.
 * Q. Is Ubuntu 20.04 supported?
   * A. No. Ubuntu 22.04 only for now.
 * Q. Is ROS 2 Foxy/Galactic supported?
-  * A. No. ROS 2 Humble only for now.
+  * A. No. ROS 2 Jazzy only for now.
 * Q. `colcon build` shows `1 package had stderr output: mini_pupper_driver`.
   * A. The following warnings can be safely ignored. See [mini_pupper_ros#45](https://github.com/mangdangroboticsclub/mini_pupper_ros/pull/45#discussion_r1104759104) for details.
   ```

--- a/mini_pupper_fleet/README.md
+++ b/mini_pupper_fleet/README.md
@@ -194,7 +194,7 @@ Main coordination launch file that handles fleet-level control and per-robot nam
 
 ### ROS 2 Packages
 ```bash
-sudo apt install ros-humble-tf2 ros-humble-tf2-geometry-msgs
+sudo apt install ros-jazzy-tf2 ros-jazzy-tf2-geometry-msgs
 ```
 
 ### System Dependencies

--- a/mini_pupper_tracking/README.md
+++ b/mini_pupper_tracking/README.md
@@ -82,7 +82,7 @@ pip install flask onnxruntime motpy
 
 ```bash
 # ROS2 dependencies
-sudo apt install ros-humble-imu-filter-madgwick ros-humble-tf-transformations
+sudo apt install ros-jazzy-imu-filter-madgwick ros-jazzy-tf-transformations
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Update CI workflow from ROS 2 Humble to ROS 2 Jazzy (`ROS_DISTRO: jazzy`)
- Replace Humble documentation links/badges with Jazzy equivalents
- Update apt dependency examples from `ros-humble-*` to `ros-jazzy-*`

## What changed
1. `.github/workflows/industrial_ci.yml`
   - `ROS_DISTRO: humble` -> `ROS_DISTRO: jazzy`
2. `README.md`
   - Badge and title updated to Jazzy
   - Main description updated to Jazzy
3. `CONTRIBUTING.md`
   - ROS style guideline link switched to Jazzy docs
4. `docs/detailed-setup-guide.md`
   - Humble references switched to Jazzy
5. `mini_pupper_fleet/README.md` and `mini_pupper_tracking/README.md`
   - Apt examples updated to `ros-jazzy-*`

## Notes
- This PR focuses on CI/docs/dependency-reference migration and keeps code changes minimal.
- It is a safe first step for the Humble -> Jazzy migration effort.

/claim #125
