### PR TITLE
Upgrade ROS 2 from Humble to Jazzy

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
-; source: https://github.com/ament/ament_lint/blob/humble/ament_flake8/ament_flake8/configuration/ament_flake8.ini
+; source: https://github.com/ament/ament_lint/blob/jazzy/ament_flake8/ament_flake8/configuration/ament_flake8.ini
 [flake8]
 extend-ignore = B902,C816,D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404,I202
 import-order-style = google

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - { ROS_DISTRO: humble, ROS_REPO: ros }
+          - { ROS_DISTRO: jazzy, ROS_REPO: ros }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ as per clause 5 of the Apache 2.0 License:
 
 ### Code Style
 
-We follow the [ROS code style guidelines](https://docs.ros.org/en/humble/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html) as closely as possible.
+We follow the [ROS code style guidelines](https://docs.ros.org/en/jazzy/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html) as closely as possible.
 Please ensure that any new contributions are compatible with C++17 and Python3.x.
 
 To check Python code style, run the following command in the ROS workspace.

--- a/Dockerfile.tracking
+++ b/Dockerfile.tracking
@@ -1,11 +1,11 @@
-FROM ros:humble-ros-base
+FROM ros:jazzy-ros-base
 
 RUN apt-get update && apt-get install -y \
     python3-pip \
-    ros-humble-cv-bridge \
-    ros-humble-tf-transformations \
-    ros-humble-sensor-msgs \
-    ros-humble-geometry-msgs \
+    ros-jazzy-cv-bridge \
+    ros-jazzy-tf-transformations \
+    ros-jazzy-sensor-msgs \
+    ros-jazzy-geometry-msgs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python packages with compatible versions
@@ -28,7 +28,7 @@ WORKDIR /ros2_ws
 RUN pip install --upgrade pip && pip cache purge
 
 # Build the ROS workspace
-RUN bash -c "source /opt/ros/humble/setup.bash && colcon build"
+RUN bash -c "source /opt/ros/jazzy/setup.bash && colcon build"
 
 # Copy entrypoint script
 COPY entrypoint.sh /ros2_ws/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![ROS2 VERSION](https://img.shields.io/badge/ROS-ROS%202%20Humble-brightgreen)](http://docs.ros.org/en/humble/index.html)
+[![ROS2 VERSION](https://img.shields.io/badge/ROS-ROS%202%20Jazzy-brightgreen)](http://docs.ros.org/en/jazzy/index.html)
 &nbsp;
-[![Ubuntu VERSION](https://img.shields.io/badge/Ubuntu-22.04-green)](https://ubuntu.com/)
+[![Ubuntu VERSION](https://img.shields.io/badge/Ubuntu-24.04-green)](https://ubuntu.com/)
 &nbsp;
 [![LICENSE](https://img.shields.io/badge/license-Apache--2.0-informational)](https://github.com/mangdangroboticsclub/mini_pupper_ros/blob/ros2/LICENSE)
 &nbsp;
@@ -10,13 +10,13 @@
 &nbsp;
 [![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2FLeggedRobot)](https://twitter.com/LeggedRobot)
 
-# Mini Pupper ROS 2 Humble
+# Mini Pupper ROS 2 Jazzy
 
 <p align="left">
   <img src="imgs/mini_pupper_2.jpg" alt="Mini Pupper 2" width="480"/>
 </p>
 
-A comprehensive ROS 2 robotics platform for autonomous navigation, computer vision, and multi-robot coordination. Built for research, education, and development on Ubuntu 22.04 with ROS 2 Humble.
+A comprehensive ROS 2 robotics platform for autonomous navigation, computer vision, and multi-robot coordination. Built for research, education, and development on Ubuntu 24.04 with ROS 2 Jazzy.
 
 ## Key Capabilities
 
@@ -43,7 +43,9 @@ Programmable dance sequences with audio synchronization capabilities.
 ## Quick Start
 
 ### Pre-built Images
-Flash the ready-to-use image containing Ubuntu 22.04, ROS 2 Humble, and all Mini Pupper packages:
+Flash the ready-to-use image containing Ubuntu 24.04, ROS 2 Jazzy, and all Mini Pupper packages.
+
+> **Note**: Updated Jazzy-based images are coming soon. In the meantime, the Ubuntu 22.04 + ROS 2 Humble images below remain available for reference:
 - **Mini Pupper 2**: [2024Oct.12.Ubuntu22.04.MD-MiniPupper2-Y.ROS2Humble.zip](https://drive.google.com/drive/folders/1_HNbIb2RDmHpwECjqiVlkylvU19BSfOh?usp=sharing)
 - **Mini Pupper**: [2024Oct.12.Ubuntu22.04.MD-MiniPupper.ROS2Humble.zip](https://drive.google.com/drive/folders/1jJm_6qBIYGGp2dpZNm668D0eH1JpfCqn?usp=sharing)
 

--- a/docs/detailed-setup-guide.md
+++ b/docs/detailed-setup-guide.md
@@ -7,7 +7,7 @@ For a more detailed guide, please refer to our [online documentation](https://mi
 
 Supported Software versions
 
-* Ubuntu 22.04 + ROS 2 Humble
+* Ubuntu 24.04 + ROS 2 Jazzy
 
 Supported Hardware versions
 
@@ -27,11 +27,11 @@ __Please note that the setup of PC and the mini pupper is separated__
 ### 1.1 Mini Pupper Setup
 
 Mini Pupper Setup corresponds to the Raspberry Pi on your Mini Pupper.  
-Ubuntu 22.04 is required.
+Ubuntu 24.04 is required.
 
 Before installation, you need to install the BSP(board support package) repo for your [Mini Pupper 2](https://github.com/mangdangroboticsclub/mini_pupper_2_bsp) or [Mini Pupper](https://github.com/mangdangroboticsclub/mini_pupper_bsp.git).
 
-After installing the driver software, install ROS 2 Humble is required, if the installation is unsuccessful, repeat the steps to install the package again.  
+After installing the driver software, install ROS 2 Jazzy is required, if the installation is unsuccessful, repeat the steps to install the package again.  
 
 ```sh
 cd ~
@@ -42,7 +42,7 @@ cd mini_pupper_ros
 
 Reference(Just for reference, don't need to do it again.): 
 
-[installation document for ROS Humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) or
+[installation document for ROS Jazzy](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html) or
 
 [unofficial ROS 2 installation script](https://github.com/Tiryoh/ros2_setup_scripts_ubuntu)
 
@@ -52,7 +52,7 @@ Reference(Just for reference, don't need to do it again.):
 PC Setup corresponds to PC (your desktop or laptop PC) for controlling Mini Pupper remotely or execute simulator, if the installation is unsuccessful, repeat the steps to install the package again.  
 __Do not apply these PC Setup commands to your Raspberry Pi on Mini Pupper.__
 
-Ubuntu 22.04 + ROS 2 Humble is required.  
+Ubuntu 24.04 + ROS 2 Jazzy is required.  
 
 ```sh
 cd ~
@@ -63,7 +63,7 @@ cd mini_pupper_ros
 
 Reference(Just for reference, don't need to do it again.): 
 
-[installation document for ROS Humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) or
+[installation document for ROS Jazzy](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html) or
 
 [unofficial ROS 2 installation script](https://github.com/Tiryoh/ros2_setup_scripts_ubuntu)
 
@@ -437,9 +437,9 @@ limitations under the License.
 ## FAQ
 
 * Q. Is Ubuntu 20.04 supported?
-  * A. No. Ubuntu 22.04 only for now.
+  * A. No. Ubuntu 24.04 only for now.
 * Q. Is ROS 2 Foxy/Galactic supported?
-  * A. No. ROS 2 Humble only for now.
+  * A. No. ROS 2 Jazzy only for now.
 * Q. `colcon build` shows `1 package had stderr output: mini_pupper_driver`.
   * A. The following warnings can be safely ignored. See [mini_pupper_ros#45](https://github.com/mangdangroboticsclub/mini_pupper_ros/pull/45#discussion_r1104759104) for details.
   ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Source ROS2
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 
 # Source workspace
 source /ros2_ws/install/setup.bash

--- a/mini_pupper_driver/launch/imu_interface.launch.py
+++ b/mini_pupper_driver/launch/imu_interface.launch.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # This program is referred to the official ros guide link，
-# https://docs.ros.org/en/humble/Tutorials/Intermediate/Launch/Creating-Launch-Files.html
+# https://docs.ros.org/en/jazzy/Tutorials/Intermediate/Launch/Creating-Launch-Files.html
 
 from launch import LaunchDescription
 from launch_ros.actions import Node

--- a/mini_pupper_fleet/README.md
+++ b/mini_pupper_fleet/README.md
@@ -194,7 +194,7 @@ Main coordination launch file that handles fleet-level control and per-robot nam
 
 ### ROS 2 Packages
 ```bash
-sudo apt install ros-humble-tf2 ros-humble-tf2-geometry-msgs
+sudo apt install ros-jazzy-tf2 ros-jazzy-tf2-geometry-msgs
 ```
 
 ### System Dependencies
@@ -323,6 +323,6 @@ This package is licensed under the Apache-2.0 License. See individual source fil
 
 ## Compatibility
 
-- **ROS 2**: Humble  
-- **Platform**: Ubuntu 22.04 LTS  
+- **ROS 2**: Jazzy  
+- **Platform**: Ubuntu 24.04 LTS  
 - **Hardware**: Mini Pupper robots with Stanford Controller  

--- a/mini_pupper_tracking/README.md
+++ b/mini_pupper_tracking/README.md
@@ -82,7 +82,7 @@ pip install flask onnxruntime motpy
 
 ```bash
 # ROS2 dependencies
-sudo apt install ros-humble-imu-filter-madgwick ros-humble-tf-transformations
+sudo apt install ros-jazzy-imu-filter-madgwick ros-jazzy-tf-transformations
 ```
 
 ---
@@ -250,6 +250,6 @@ This package is licensed under the Apache-2.0 License. See individual source fil
 
 ## Compatibility
 
-- **ROS 2**: Humble
-- **Platform**: Ubuntu 22.04 LTS
+- **ROS 2**: Jazzy
+- **Platform**: Ubuntu 24.04 LTS
 - **Hardware**: Mini Pupper robots with Stanford Controller

--- a/pc_install.sh
+++ b/pc_install.sh
@@ -16,8 +16,8 @@ sudo apt update
 if ! [ -d "ros2_setup_scripts_ubuntu" ]; then
   git clone https://github.com/Tiryoh/ros2_setup_scripts_ubuntu.git
 fi
-~/ros2_setup_scripts_ubuntu/ros2-humble-ros-base-main.sh
-source /opt/ros/humble/setup.bash
+~/ros2_setup_scripts_ubuntu/ros2-jazzy-ros-base-main.sh
+source /opt/ros/jazzy/setup.bash
 
 # Create ROS 2 workspace and clone Mini Pupper ROS repository
 mkdir -p ~/ros2_ws/src
@@ -30,8 +30,8 @@ vcs import < mini_pupper_ros/.minipupper.repos --recursive
 # Install dependencies and build the ROS 2 packages
 cd ~/ros2_ws
 rosdep install --from-paths src --ignore-src -r -y
-sudo apt install -y ros-humble-teleop-twist-keyboard ros-humble-teleop-twist-joy
-sudo apt install -y ros-humble-v4l2-camera ros-humble-image-transport-plugins
-sudo apt install -y ros-humble-rqt*
+sudo apt install -y ros-jazzy-teleop-twist-keyboard ros-jazzy-teleop-twist-joy
+sudo apt install -y ros-jazzy-v4l2-camera ros-jazzy-image-transport-plugins
+sudo apt install -y ros-jazzy-rqt*
 pip3 install simple_pid
 colcon build --symlink-install

--- a/pupper_install.sh
+++ b/pupper_install.sh
@@ -16,9 +16,9 @@ echo "setup.sh started at $(date)"
 # check Ubuntu version
 source /etc/os-release
 
-if [[ $UBUNTU_CODENAME != 'jammy' ]]
+if [[ $UBUNTU_CODENAME != 'noble' ]]
 then
-    echo "Ubuntu 22.04 LTS (Jammy Jellyfish) is required"
+    echo "Ubuntu 24.04 LTS (Noble Numbat) is required"
     echo "You are using $VERSION"
     exit 1
 fi
@@ -38,12 +38,12 @@ cd ~
 sudo apt-get update
 sudo apt -y install python3-pip python3-venv python3-virtualenv
 
-#Auto install ROS2 Humble
+#Auto install ROS2 Jazzy
 if ! [ -d "ros2_setup_scripts_ubuntu" ]; then
   git clone https://github.com/Tiryoh/ros2_setup_scripts_ubuntu.git
 fi
-~/ros2_setup_scripts_ubuntu/ros2-humble-ros-base-main.sh
-source /opt/ros/humble/setup.bash
+~/ros2_setup_scripts_ubuntu/ros2-jazzy-ros-base-main.sh
+source /opt/ros/jazzy/setup.bash
 
 #clone mini pupper 2 ros2 repo
 mkdir -p ~/ros2_ws/src
@@ -61,9 +61,9 @@ touch mini_pupper_ros/mini_pupper_navigation/AMENT_IGNORE
 # install dependencies without unused heavy packages
 cd ~/ros2_ws
 rosdep install --from-paths src --ignore-src -r -y --skip-keys=joint_state_publisher_gui --skip-keys=rviz2 --skip-keys=gazebo_plugins --skip-keys=velodyne_gazebo_plugins
-sudo apt install ros-humble-teleop-twist-keyboard
-sudo apt install ros-humble-teleop-twist-joy
-sudo apt install -y ros-humble-v4l2-camera ros-humble-image-transport-plugins
+sudo apt install ros-jazzy-teleop-twist-keyboard
+sudo apt install ros-jazzy-teleop-twist-joy
+sudo apt install -y ros-jazzy-v4l2-camera ros-jazzy-image-transport-plugins
 pip3 install simple_pid
 
 #colcon build --symlink-install


### PR DESCRIPTION
Migrates the entire codebase from ROS 2 Humble (Ubuntu 22.04) to ROS 2 Jazzy (Ubuntu 24.04).

## Changes

- **CI** (`.github/workflows/industrial_ci.yml`): `ROS_DISTRO: humble` → `jazzy`
- **Install scripts** (`pc_install.sh`, `pupper_install.sh`):
  - Ubuntu version guard: `jammy` → `noble` (22.04 → 24.04)
  - Setup script: `ros2-humble-ros-base-main.sh` → `ros2-jazzy-ros-base-main.sh`
  - All `ros-humble-*` apt packages → `ros-jazzy-*`
- **Docker** (`Dockerfile.tracking`, `entrypoint.sh`): base image and sourced setup updated to Jazzy
- **Docs** (`README.md`, `docs/detailed-setup-guide.md`, `mini_pupper_fleet/README.md`, `mini_pupper_tracking/README.md`, `CONTRIBUTING.md`): version badges, compatibility notes, apt install snippets, and linked docs URLs updated throughout
- **`README.md`**: added note that pre-built images (still named Ubuntu 22.04/Humble) are from the prior release; Jazzy images are forthcoming
- closes #125
- /claim #125 