### PR TITLE
fix: upgrade ros2 humble to jazzy

### DIFF
--- a/Dockerfile.tracking
+++ b/Dockerfile.tracking
@@ -1,4 +1,4 @@
-FROM ros:humble-ros-base
+FROM ros:jazzy-ros-base
 
 RUN apt-get update && apt-get install -y \
     python3-pip \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Source ROS2
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 
 # Source workspace
 source /ros2_ws/install/setup.bash


### PR DESCRIPTION
Fixes #125

## Changes
- `entrypoint.sh`
- `Dockerfile.tracking`
- `Dockerfile.tracking`

## Summary
Automated fix for: Upgrade ROS2 Humble to Jazzy