### PR TITLE
fix: Upgrade ROS2 Humble to Jazzy

### DIFF
--- a/mini_pupper_simulation/launch/ros2_controllers.launch.py
+++ b/mini_pupper_simulation/launch/ros2_controllers.launch.py
@@ -25,14 +25,14 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster"],
+        arguments=["joint_state_broadcaster", "--controller-manager", "controller_manager"],
         output='screen'
     )
 
     joint_group_effort_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_group_effort_controller"],
+        arguments=["joint_group_effort_controller", "--controller-manager", "controller_manager"],
         output='screen'
     )
 

--- a/mini_pupper_tracking/README.md
+++ b/mini_pupper_tracking/README.md
@@ -82,7 +82,7 @@ pip install flask onnxruntime motpy
 
 ```bash
 # ROS2 dependencies
-sudo apt install ros-humble-imu-filter-madgwick ros-humble-tf-transformations
+sudo apt install ros-jazzy-imu-filter-madgwick ros-jazzy-tf-transformations
 ```
 
 ---
@@ -250,6 +250,6 @@ This package is licensed under the Apache-2.0 License. See individual source fil
 
 ## Compatibility
 
-- **ROS 2**: Humble
-- **Platform**: Ubuntu 22.04 LTS
+- **ROS 2**: Jazzy
+- **Platform**: Ubuntu 24.04 LTS
 - **Hardware**: Mini Pupper robots with Stanford Controller


### PR DESCRIPTION
Closes #125

## What changed
To upgrade ROS2 Humble to Jazzy, we need to update the `ros-humble-*` dependencies to `ros-jazzy-*` in the documentation and adjust the `controller_manager` spawner arguments to explicitly target the controller manager node.

## Files modified
- `mini_pupper_simulation/launch/ros2_controllers.launch.py`
- `mini_pupper_tracking/README.md`

---
*Automated PR — please review.*