### PR TITLE
chore: upgrade ROS2 from Humble to Jazzy

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - { ROS_DISTRO: humble, ROS_REPO: ros }
+          - { ROS_DISTRO: jazzy, ROS_REPO: ros }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile.tracking
+++ b/Dockerfile.tracking
@@ -1,11 +1,11 @@
-FROM ros:humble-ros-base
+FROM ros:jazzy-ros-base
 
 RUN apt-get update && apt-get install -y \
     python3-pip \
-    ros-humble-cv-bridge \
-    ros-humble-tf-transformations \
-    ros-humble-sensor-msgs \
-    ros-humble-geometry-msgs \
+    ros-jazzy-cv-bridge \
+    ros-jazzy-tf-transformations \
+    ros-jazzy-sensor-msgs \
+    ros-jazzy-geometry-msgs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python packages with compatible versions
@@ -28,7 +28,7 @@ WORKDIR /ros2_ws
 RUN pip install --upgrade pip && pip cache purge
 
 # Build the ROS workspace
-RUN bash -c "source /opt/ros/humble/setup.bash && colcon build"
+RUN bash -c "source /opt/ros/jazzy/setup.bash && colcon build"
 
 # Copy entrypoint script
 COPY entrypoint.sh /ros2_ws/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Source ROS2
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 
 # Source workspace
 source /ros2_ws/install/setup.bash

--- a/mini_pupper_driver/launch/imu_interface.launch.py
+++ b/mini_pupper_driver/launch/imu_interface.launch.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # This program is referred to the official ros guide link，
-# https://docs.ros.org/en/humble/Tutorials/Intermediate/Launch/Creating-Launch-Files.html
+# https://docs.ros.org/en/jazzy/Tutorials/Intermediate/Launch/Creating-Launch-Files.html
 
 from launch import LaunchDescription
 from launch_ros.actions import Node

--- a/pc_install.sh
+++ b/pc_install.sh
@@ -16,8 +16,8 @@ sudo apt update
 if ! [ -d "ros2_setup_scripts_ubuntu" ]; then
   git clone https://github.com/Tiryoh/ros2_setup_scripts_ubuntu.git
 fi
-~/ros2_setup_scripts_ubuntu/ros2-humble-ros-base-main.sh
-source /opt/ros/humble/setup.bash
+~/ros2_setup_scripts_ubuntu/ros2-jazzy-ros-base-main.sh
+source /opt/ros/jazzy/setup.bash
 
 # Create ROS 2 workspace and clone Mini Pupper ROS repository
 mkdir -p ~/ros2_ws/src
@@ -30,8 +30,8 @@ vcs import < mini_pupper_ros/.minipupper.repos --recursive
 # Install dependencies and build the ROS 2 packages
 cd ~/ros2_ws
 rosdep install --from-paths src --ignore-src -r -y
-sudo apt install -y ros-humble-teleop-twist-keyboard ros-humble-teleop-twist-joy
-sudo apt install -y ros-humble-v4l2-camera ros-humble-image-transport-plugins
-sudo apt install -y ros-humble-rqt*
+sudo apt install -y ros-jazzy-teleop-twist-keyboard ros-jazzy-teleop-twist-joy
+sudo apt install -y ros-jazzy-v4l2-camera ros-jazzy-image-transport-plugins
+sudo apt install -y ros-jazzy-rqt*
 pip3 install simple_pid
 colcon build --symlink-install

--- a/pupper_install.sh
+++ b/pupper_install.sh
@@ -16,9 +16,9 @@ echo "setup.sh started at $(date)"
 # check Ubuntu version
 source /etc/os-release
 
-if [[ $UBUNTU_CODENAME != 'jammy' ]]
+if [[ $UBUNTU_CODENAME != 'noble' ]]
 then
-    echo "Ubuntu 22.04 LTS (Jammy Jellyfish) is required"
+    echo "Ubuntu 24.04 LTS (Noble Numbat) is required for ROS2 Jazzy"
     echo "You are using $VERSION"
     exit 1
 fi
@@ -38,12 +38,12 @@ cd ~
 sudo apt-get update
 sudo apt -y install python3-pip python3-venv python3-virtualenv
 
-#Auto install ROS2 Humble
+#Auto install ROS2 Jazzy
 if ! [ -d "ros2_setup_scripts_ubuntu" ]; then
   git clone https://github.com/Tiryoh/ros2_setup_scripts_ubuntu.git
 fi
-~/ros2_setup_scripts_ubuntu/ros2-humble-ros-base-main.sh
-source /opt/ros/humble/setup.bash
+~/ros2_setup_scripts_ubuntu/ros2-jazzy-ros-base-main.sh
+source /opt/ros/jazzy/setup.bash
 
 #clone mini pupper 2 ros2 repo
 mkdir -p ~/ros2_ws/src


### PR DESCRIPTION
## Overview

This PR upgrades the ROS2 distribution from **Humble Hawksbill** (EOL: May 2027, Ubuntu 22.04) to **Jazzy Jalisco** (LTS: May 2029, Ubuntu 24.04).

## Changes

| File | Change |
|------|--------|
| `Dockerfile.tracking` | Base image → `ros:jazzy-ros-base`, all `ros-humble-*` → `ros-jazzy-*` |
| `.github/workflows/industrial_ci.yml` | CI matrix: `ROS_DISTRO: humble` → `ROS_DISTRO: jazzy` |
| `entrypoint.sh` | ROS setup script path → `/opt/ros/jazzy/setup.bash` |
| `pc_install.sh` | Install script → jazzy, package names updated |
| `pupper_install.sh` | Ubuntu version check: `jammy` → `noble`, install script → jazzy |
| `mini_pupper_driver/launch/imu_interface.launch.py` | Docs URL updated to jazzy |

## Notes

- ROS2 Jazzy requires **Ubuntu 24.04 LTS (Noble Numbat)**. The `pupper_install.sh` OS check has been updated accordingly.
- The `ros2_setup_scripts_ubuntu` installer script has been updated to use `ros2-jazzy-ros-base-main.sh`.
- All package naming conventions (`ros-humble-*` → `ros-jazzy-*`) follow the standard ROS2 naming scheme.

Please review and let me know if any package names differ in Jazzy or if additional configuration changes are needed.

Closes #125
